### PR TITLE
Handle stop_process from Slips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+p2p4slips

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build:
+	go build

--- a/slistener/slipsListener.go
+++ b/slistener/slipsListener.go
@@ -32,6 +32,11 @@ func (s *SListener) Run() {
 func (s *SListener) handleCommand(message string) {
 	fmt.Println("[SLISTENER] New message from REDIS:", message)
 
+	if message == "stop_process" {
+		fmt.Println("[SLISTENER] Stop process received, awaiting termination signal..")
+		return
+	}
+
 	ps, err := s.parseJson(message)
 
 	if err != nil {


### PR DESCRIPTION
* once `stop_process` was received the module printed ugly status
* now it handles this message as well, there's no need to exit the code as python module sends `SIGINT` anyway