### PR TITLE
p2p:main.go: use the host+port given as a param with --redis-db

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	fmt.Printf("[MAIN] Pigeon is starting on TCP Port %d\n", cfg.ListenPort)
 
 	// initialize database interface
-	database.DBW = &database.DBWrapper{DbAddress: "", RdbGoPy: cfg.RedisChannelGoPy,
+	database.DBW = &database.DBWrapper{DbAddress: cfg.RedisDb, RdbGoPy: cfg.RedisChannelGoPy,
 		RdbPyGo: cfg.RedisChannelPyGo}
 	var dbSuccess = database.DBW.InitDB()
 


### PR DESCRIPTION
fixes https://github.com/stratosphereips/StratosphereLinuxIPS/issues/1693